### PR TITLE
Updated tests

### DIFF
--- a/src/Traits/HasChart.php
+++ b/src/Traits/HasChart.php
@@ -32,7 +32,9 @@ trait HasChart
         });
 
         static::created(function ($model) {
-            $model->novaChartjsMetricValue()->create(['metric_values' => $model->unsavedMetricValues]);
+            if (! empty($model->unsavedMetricValues)) {
+                $model->novaChartjsMetricValue()->create(['metric_values' => $model->unsavedMetricValues]);
+            }
         });
     }
 

--- a/tests/Unit/ChartableTest.php
+++ b/tests/Unit/ChartableTest.php
@@ -43,8 +43,11 @@ class ChartableTest extends TestCase
 
         $this->assertNull($chartable->novaChartjsMetricValue);
         $chartable->save();
-        $this->assertInstanceOf(NovaChartjsMetricValue::class, $chartable->fresh()->novaChartjsMetricValue);
-        $this->assertEquals($testArray, $chartable->fresh()->novaChartjsMetricValue->metric_values);
+
+        tap($chartable->fresh(), function ($chartable) use ($testArray) {
+            $this->assertInstanceOf(NovaChartjsMetricValue::class, $chartable->novaChartjsMetricValue);
+            $this->assertEquals($testArray, $chartable->novaChartjsMetricValue->metric_values);
+        });
     }
 
     /** @test **/
@@ -56,8 +59,10 @@ class ChartableTest extends TestCase
         $this->testChartable->novaChartjsMetricValue = $testArray;
         $this->testChartable->save();
 
-        $this->assertInstanceOf(NovaChartjsMetricValue::class, $this->testChartable->fresh()->novaChartjsMetricValue);
-        $this->assertEquals($testArray, $this->testChartable->fresh()->novaChartjsMetricValue->metric_values);
+        tap($this->testChartable->fresh(), function ($chartable) use ($testArray) {
+            $this->assertInstanceOf(NovaChartjsMetricValue::class, $chartable->novaChartjsMetricValue);
+            $this->assertEquals($testArray, $chartable->novaChartjsMetricValue->metric_values);
+        });
     }
 
     /** @test **/
@@ -72,8 +77,10 @@ class ChartableTest extends TestCase
         $this->testChartable->novaChartjsMetricValue = $testArray;
         $this->testChartable->save();
 
-        $this->assertNotEquals($metricValue->metric_values, $this->testChartable->fresh()->novaChartjsMetricValue->metric_values);
-        $this->assertEquals($testArray, $this->testChartable->fresh()->novaChartjsMetricValue->metric_values);
+        tap($this->testChartable->fresh(), function ($chartable) use ($testArray, $metricValue) {
+            $this->assertNotEquals($metricValue->metric_values, $chartable->novaChartjsMetricValue->metric_values);
+            $this->assertEquals($testArray, $chartable->novaChartjsMetricValue->metric_values);
+        });
     }
 
     /**

--- a/tests/Unit/ChartableTest.php
+++ b/tests/Unit/ChartableTest.php
@@ -5,6 +5,7 @@ namespace KirschbaumDevelopment\NovaChartjs\Tests\Unit;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use KirschbaumDevelopment\NovaChartjs\Tests\TestCase;
+use KirschbaumDevelopment\NovaChartjs\Tests\Chartable;
 use KirschbaumDevelopment\NovaChartjs\Models\NovaChartjsMetricValue;
 
 class ChartableTest extends TestCase
@@ -31,6 +32,48 @@ class ChartableTest extends TestCase
         $this->addNovaChartjsMetricValueToChartable();
 
         $this->assertInstanceOf(NovaChartjsMetricValue::class, $this->testChartable->novaChartjsMetricValue);
+    }
+
+    /** @test **/
+    public function a_chartable_can_automatically_create_metric_values_in_relationship_if_passed_before_creating()
+    {
+        $chartable = new Chartable(['name' => 'Unsaved Chartable']);
+        $testArray = ['January' => 10, 'February' => 30];
+        $chartable->novaChartjsMetricValue = $testArray;
+
+        $this->assertNull($chartable->novaChartjsMetricValue);
+        $chartable->save();
+        $this->assertInstanceOf(NovaChartjsMetricValue::class, $chartable->fresh()->novaChartjsMetricValue);
+        $this->assertEquals($testArray, $chartable->fresh()->novaChartjsMetricValue->metric_values);
+    }
+
+    /** @test **/
+    public function a_chartable_can_automatically_create_new_metric_values_in_relationship_if_needed_and_passed_before_updating()
+    {
+        $this->assertNull($this->testChartable->novaChartjsMetricValue);
+
+        $testArray = ['January' => 10, 'February' => 30];
+        $this->testChartable->novaChartjsMetricValue = $testArray;
+        $this->testChartable->save();
+
+        $this->assertInstanceOf(NovaChartjsMetricValue::class, $this->testChartable->fresh()->novaChartjsMetricValue);
+        $this->assertEquals($testArray, $this->testChartable->fresh()->novaChartjsMetricValue->metric_values);
+    }
+
+    /** @test **/
+    public function a_chartable_can_automatically_update_metric_values_in_relationship_if_passed_before_updating()
+    {
+        $metricValue = factory(NovaChartjsMetricValue::class)->make();
+        $this->addNovaChartjsMetricValueToChartable($metricValue);
+        $this->assertInstanceOf(NovaChartjsMetricValue::class, $this->testChartable->novaChartjsMetricValue);
+        $this->assertEquals($metricValue->metric_values, $this->testChartable->novaChartjsMetricValue->metric_values);
+
+        $testArray = ['January' => 10, 'February' => 30];
+        $this->testChartable->novaChartjsMetricValue = $testArray;
+        $this->testChartable->save();
+
+        $this->assertNotEquals($metricValue->metric_values, $this->testChartable->fresh()->novaChartjsMetricValue->metric_values);
+        $this->assertEquals($testArray, $this->testChartable->fresh()->novaChartjsMetricValue->metric_values);
     }
 
     /**


### PR DESCRIPTION
1. Updated tests to prove that HasChart can create and update metric values passed to chartable directly
2. Updated HasCgarts to not create empty model for novaChartjsMetricValue if no value is passed.